### PR TITLE
BioImgFactory: fix NullPointerException

### DIFF
--- a/src/main/java/it/crs4/features/BioImgFactory.java
+++ b/src/main/java/it/crs4/features/BioImgFactory.java
@@ -122,10 +122,10 @@ public class BioImgFactory {
     }
     int[] zct = reader.getZCTCoords(no);
 
-    if (!zs.isEmpty() && !zs.contains(zct[0])) {
+    if (null != zs && !zs.contains(zct[0])) {
       return null;
     }
-    if (!ts.isEmpty() && !ts.contains(zct[2])) {
+    if (null != ts && !ts.contains(zct[2])) {
       return null;
     }
 


### PR DESCRIPTION
This was breaking the "no selection" use case and thus the existing unit test due to missing checks for `null`. The checks for non-empty set, OTOH, were redundant.
